### PR TITLE
Fixes multiple collection and version migrations

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "extends": "etaskr",
+  "rules": {
+    "no-var": 0
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
 npm-debug.log
+.idea
 node_modules
 migrations/
+coverage

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -11,47 +11,46 @@ var versionsFile = migrations_path + '.versions.json';
 var create;
 
 var stringify = function(json) {
-  return JSON.stringify(json, null, 4);
+    return JSON.stringify(json, null, 4);
 };
 
 var incrementVersion = function(collection) {
-  var versions = require(versionsFile);
-  var currentVersion = versions[collection];
-  var nextVersion = currentVersion ? currentVersion + 1 : 1;
+    var versions = require(versionsFile);
+    var currentVersion = versions[collection];
+    var nextVersion = currentVersion ? currentVersion + 1 : 1;
 
-  versions[collection] = nextVersion;
-  fs.writeFileSync(versionsFile, stringify(versions));
+    versions[collection] = nextVersion;
+    fs.writeFileSync(versionsFile, stringify(versions));
 };
 
 exports.create = create = function(collection, label) {
-  collection = collection.toLowerCase();
+    collection = collection.toLowerCase();
 
-  var versions = require(versionsFile);
-  var templateFileName = path.join(__dirname, '..', 'templates', 'table-0000-label.js');
-  var migrationLabel = slug(label);
-  var version = versions[collection] || 0;
-  var nextVersion = version + 1;
-  var fileParts = [
-    collection,
-    String('0000' + nextVersion).slice(-4),
-    migrationLabel
-  ];
-  var fileName = migrations_path + fileParts.join('-') + '.js';
+    var versions = require(versionsFile);
+    var templateFileName = path.join(__dirname, '..', 'templates', 'table-0000-label.js');
+    var migrationLabel = slug(label);
+    var version = versions[collection] || 0;
+    var nextVersion = version + 1;
+    var fileParts = [
+        collection,
+        String('0000' + nextVersion).slice(-4),
+        migrationLabel
+    ];
+    var fileName = migrations_path + fileParts.join('-') + '.js';
 
-  // Copy template file to migration file
-  fs.writeFileSync(fileName, fs.readFileSync(templateFileName));
+    // Copy template file to migration file
+    fs.writeFileSync(fileName, fs.readFileSync(templateFileName));
 
-  // Update migration versions
-  incrementVersion(collection);
+    // Update migration versions
+    incrementVersion(collection);
 
-  console.log('\nCreated ./migrations/' + fileParts.join('-') + '.js\n');
+    console.log('\nCreated ./migrations/' + fileParts.join('-') + '.js\n');
 };
 
 if (require.main === module) {
-  switch(process.argv[2]) {
-    case 'create':
-      create(process.argv[3].toLowerCase(), process.argv.slice(4).join('-'));
-      break;
-  }
+    switch (process.argv[2]) {
+        case 'create':
+            create(process.argv[3].toLowerCase(), process.argv.slice(4).join('-'));
+            break;
+    }
 }
-

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,40 +1,51 @@
 var fs = require('fs');
 
+/**
+ * Gets the current version of the migration for the provided collection and directory.
+ *
+ * @param directory
+ * @param collection
+ * @returns {number}
+ */
 exports.getCurrentVersion = function(directory, collection) {
-  return (require(directory + '.versions.json')[collection.toLowerCase()]);
+    try {
+        return (require(directory + '.versions.json')[collection.toLowerCase()]);
+    } catch (err) {
+        throw new Error('Could not read versions file: ' + directory + '.versions.json');
+    }
 };
 
 /**
  * List all migration files.
  */
 exports.list = function(directory, collection) {
-  return fs.readdirSync(directory).filter(function(fileName) {
-    return fileName.match(new RegExp('^' + collection.toLowerCase()));
-  }).sort();
+    return fs.readdirSync(directory).filter(function(fileName) {
+        return fileName.match(new RegExp('^' + collection.toLowerCase()));
+    }).sort();
 };
 
 /**
  * Provide a hash of files by version.
  */
 exports.listByVersion = function(directory, collection) {
-  var list = exports.list(directory, collection.toLowerCase());
+    var list = exports.list(directory, collection.toLowerCase());
 
-  return list.reduce(function(prev, value, index) {
-    var version = parseInt(value.match(/-(\d{4})-/)[1]);
-    prev[version] = value;
-    return prev;
-  }, {});
-}
+    return list.reduce(function(prev, value) {
+        var version = parseInt(value.match(/-(\d{4})-/)[1], 10);
+        prev[version] = value;
+        return prev;
+    }, {});
+};
 
 /**
  * Returns a single migration file
  */
 exports.getVersion = function(directory, collection, version) {
-  var paddedVersion = String('0000' + version).slice(-4);
+    var paddedVersion = String('0000' + version).slice(-4);
 
-  var versions = fs.readdirSync(directory).filter(function(fileName) {
-    return fileName.match(new RegExp('^' + collection.toLowerCase() + '-' + paddedVersion));
-  });
+    var versions = fs.readdirSync(directory).filter(function(fileName) {
+        return fileName.match(new RegExp('^' + collection.toLowerCase() + '-' + paddedVersion));
+    });
 
-  return versions.length > 0 ? versions[0] : false;
+    return versions.length > 0 ? versions[0] : false;
 };

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -113,7 +113,8 @@ function Plugin(schema, options) {
      * @param data
      */
     var postInit = function(data) {
-        data.update(data.toObject(), errorHandler);
+        // ensure that the data is stripped back, especially the populated fields to ensure it saves correctly.
+        data.update(data.toObject({depopulate: true, getters: false, virtuals: false}), errorHandler);
     };
 
     var errorHandler = function(error) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -23,7 +23,7 @@ function Plugin(schema, options) {
   newField = {};
   newField[opts.version_field] = {
     type: Number,
-    default: currentVersion
+    default: currentVersion || 0
   };
 
   schema.add(newField);

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -2,22 +2,19 @@ var _ = require('lodash');
 var mongoose = require('mongoose');
 var common = require('./common');
 
-var currentVersion, migrations;
-var opts = {
-  collection: '',
-  migrations_path: process.cwd() + '/migrations/',
-  model: null,
-  version_field: '__m'
-}
-
 function Plugin(schema, options) {
   var newField;
 
-  opts = _.merge(opts, options);
+  var opts = _.merge({
+    collection: '',
+    migrations_path: process.cwd() + '/migrations/',
+    model: null,
+    version_field: '__m'
+  }, options);
   opts.collection = opts.collection.toLowerCase();
 
-  currentVersion = common.getCurrentVersion(opts.migrations_path, opts.collection);
-  migrations = common.listByVersion(opts.migrations_path, opts.collection);
+  var currentVersion = common.getCurrentVersion(opts.migrations_path, opts.collection);
+  var migrations = common.listByVersion(opts.migrations_path, opts.collection);
 
   // set VERSION_FIELD
   newField = {};
@@ -26,69 +23,69 @@ function Plugin(schema, options) {
     default: currentVersion || 0
   };
 
+  var preInit = function(next, data) {
+    data[opts.version_field] = data[opts.version_field] || 0;
+
+    // up
+    while (data[opts.version_field] < currentVersion) {
+      data = migrate(data, 'up');
+    }
+
+    // down
+    while (data[opts.version_field] > currentVersion) {
+      data = migrate(data, 'down');
+    }
+
+    next();
+  }
+
+  var migrate = function(data, action) {
+    var migration, migrationName, newData, unset;
+
+    if (action == 'up') {
+      data[opts.version_field]++;
+      migrationName = migrations[data[opts.version_field]];
+      migration = require(opts.migrations_path + migrationName).up;
+    } else if (action == 'down') {
+      migrationName = migrations[data[opts.version_field]];
+      migration = require(opts.migrations_path + migrationName).down;
+      data[opts.version_field]--;
+    }
+
+    if (!migration) {
+      console.error('mongoose-lazy-migrations', 'migration not found');
+      return data;
+    }
+
+    newData = migration(data);
+
+    if (!newData['$unset'] || typeof newData['$unset'] !== 'object') {
+      return newData;
+    }
+
+    for (var prop in newData['$unset']) {
+      delete newData[prop];
+    }
+
+    opts.model.update({ _id: newData._id }, { $unset: newData['$unset'] }, { strict: false }, errorHandler);
+
+    delete newData['$unset'];
+    return newData;
+  }
+
+  var postInit = function(data) {
+    data.update(data.toObject(), errorHandler);
+  }
+
+  var errorHandler = function(error) {
+    if (error) {
+      console.error('mongoose-lazy-migrations', error);
+    }
+  }
+
   schema.add(newField);
   schema.pre('init', preInit.bind(this));
   schema.post('init', postInit.bind(this));
 };
-
-function preInit(next, data) {
-  data[opts.version_field] = data[opts.version_field] || 0;
-
-  // up
-  while (data[opts.version_field] < currentVersion) {
-    data = migrate(data, 'up');
-  }
-
-  // down
-  while (data[opts.version_field] > currentVersion) {
-    data = migrate(data, 'down');
-  }
-
-  next();
-}
-
-function migrate(data, action) {
-  var migration, migrationName, newData, unset;
-
-  if (action == 'up') {
-    data[opts.version_field]++;
-    migrationName = migrations[data[opts.version_field]];
-    migration = require(opts.migrations_path + migrationName).up;
-  } else if (action == 'down') {
-    migrationName = migrations[data[opts.version_field]];
-    migration = require(opts.migrations_path + migrationName).down;
-    data[opts.version_field]--;
-  }
-
-  if (!migration) {
-    console.error('mongoose-lazy-migrations', 'migration not found');
-    return data;
-  }
-
-  newData = migration(data);
-
-  if (!newData['$unset'] || typeof newData['$unset'] !== 'object') {
-    return newData;
-  }
-
-  for (var prop in newData['$unset']) {
-    delete newData[prop];
-  }
-
-  opts.model.update({ _id: newData._id }, { $unset: newData['$unset'] }, { strict: false }, errorHandler);
-
-  delete newData['$unset'];
-  return newData;
-}
-
-function postInit(data) {
-  data.update(data.toObject(), errorHandler);
-}
-
-function errorHandler(error) {
-  if (error) {
-    console.error('mongoose-lazy-migrations', error);
-  }
-}
 
 module.exports = exports = Plugin;

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -3,89 +3,135 @@ var mongoose = require('mongoose');
 var common = require('./common');
 
 function Plugin(schema, options) {
-  var newField;
+    var newField;
 
-  var opts = _.merge({
-    collection: '',
-    migrations_path: process.cwd() + '/migrations/',
-    model: null,
-    version_field: '__m'
-  }, options);
-  opts.collection = opts.collection.toLowerCase();
+    var opts = _.merge({
+        collection: '',
+        migrations_path: process.cwd() + '/migrations/',
+        model: null,
+        version_field: '__m'
+    }, options);
 
-  var currentVersion = common.getCurrentVersion(opts.migrations_path, opts.collection);
-  var migrations = common.listByVersion(opts.migrations_path, opts.collection);
+    // lowercase the collection
+    opts.collection = opts.collection.toLowerCase();
 
-  // set VERSION_FIELD
-  newField = {};
-  newField[opts.version_field] = {
-    type: Number,
-    default: currentVersion || 0
-  };
+    /**
+     * Helper function that gets the current version. We use this to dynamically get the version because
+     * caching it to a variable means we can't do multiple collections.
+     *
+     * @returns {number}
+     */
+    var getCurrentVersion = function() {
+        return common.getCurrentVersion(opts.migrations_path, opts.collection) || 0;
+    };
 
-  var preInit = function(next, data) {
-    data[opts.version_field] = data[opts.version_field] || 0;
+    /**
+     * Provides a hash of files by version for the current collection.
+     */
+    var getMigrations = function() {
+        return common.listByVersion(opts.migrations_path, opts.collection);
+    };
 
-    // up
-    while (data[opts.version_field] < currentVersion) {
-      data = migrate(data, 'up');
-    }
+    /**
+     * This is where we execute the migrations before mongoose performs additional actions in its lifecycle.
+     *
+     * @param next
+     * @param data
+     */
+    var preInit = function(next, data) {
+        data[opts.version_field] = data[opts.version_field] || 0;
 
-    // down
-    while (data[opts.version_field] > currentVersion) {
-      data = migrate(data, 'down');
-    }
+        // up
+        while (data[opts.version_field] < getCurrentVersion()) {
+            data = migrate(data, 'up');
+        }
 
-    next();
-  }
+        // down
+        while (data[opts.version_field] > getCurrentVersion()) {
+            data = migrate(data, 'down');
+        }
 
-  var migrate = function(data, action) {
-    var migration, migrationName, newData, unset;
+        next();
+    };
 
-    if (action == 'up') {
-      data[opts.version_field]++;
-      migrationName = migrations[data[opts.version_field]];
-      migration = require(opts.migrations_path + migrationName).up;
-    } else if (action == 'down') {
-      migrationName = migrations[data[opts.version_field]];
-      migration = require(opts.migrations_path + migrationName).down;
-      data[opts.version_field]--;
-    }
+    /**
+     * Executes the imported migration actions.
+     *
+     * @param data
+     * @param action
+     * @returns {Object}
+     */
+    var migrate = function(data, action) {
+        var migrations = getMigrations();
+        var migration;
+        var migrationName;
+        var newData;
 
-    if (!migration) {
-      console.error('mongoose-lazy-migrations', 'migration not found');
-      return data;
-    }
+        if (action == 'up') {
+            try {
+                data[opts.version_field]++;
+                migrationName = migrations[data[opts.version_field]];
+                migration = require(opts.migrations_path + migrationName).up;
+            } catch (err) {
+                throw new Error('Could not run "up" migration file with the path ' + opts.migrations_path + migrationName);
+            }
+        } else if (action == 'down') {
+            try {
+                migrationName = migrations[data[opts.version_field]];
+                migration = require(opts.migrations_path + migrationName).down;
+                data[opts.version_field]--;
+            } catch (err) {
+                throw new Error('Could not run "down" migration file with the path ' + opts.migrations_path + migrationName);
+            }
+        }
 
-    newData = migration(data);
+        if (!migration) {
+            console.error('mongoose-lazy-migrations', 'migration not found');
+            return data;
+        }
 
-    if (!newData['$unset'] || typeof newData['$unset'] !== 'object') {
-      return newData;
-    }
+        newData = migration(data);
 
-    for (var prop in newData['$unset']) {
-      delete newData[prop];
-    }
+        if (!newData['$unset'] || typeof newData['$unset'] !== 'object') {
+            return newData;
+        }
 
-    opts.model.update({ _id: newData._id }, { $unset: newData['$unset'] }, { strict: false }, errorHandler);
+        for (var prop in newData['$unset']) {
+            delete newData[prop];
+        }
 
-    delete newData['$unset'];
-    return newData;
-  }
+        opts.model.update({_id: newData._id}, {$unset: newData['$unset']}, {strict: false}, errorHandler);
 
-  var postInit = function(data) {
-    data.update(data.toObject({ setters: false }), errorHandler);
-  }
+        delete newData['$unset'];
+        return newData;
+    };
 
-  var errorHandler = function(error) {
-    if (error) {
-      console.error('mongoose-lazy-migrations', error);
-    }
-  }
+    /**
+     * This is where the data changed in migration is saved. It is executed after the migration is complete, but before
+     * mongoose finishes its full init lifecycle.
+     *
+     * @param data
+     */
+    var postInit = function(data) {
+        data.update(data.toObject(), errorHandler);
+    };
 
-  schema.add(newField);
-  schema.pre('init', preInit.bind(this));
-  schema.post('init', postInit.bind(this));
-};
+    var errorHandler = function(error) {
+        if (error) {
+            console.error('mongoose-lazy-migrations', error);
+        }
+    };
 
-module.exports = exports = Plugin;
+    // set VERSION_FIELD
+    newField = {};
+    newField[opts.version_field] = {
+        type: Number,
+        default: getCurrentVersion()
+    };
+
+    schema.add(newField);
+    schema.pre('init', preInit.bind(this));
+    schema.post('init', postInit.bind(this));
+}
+
+module.exports = Plugin;

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -74,7 +74,7 @@ function Plugin(schema, options) {
   }
 
   var postInit = function(data) {
-    data.update(data.toObject(), errorHandler);
+    data.update(data.toObject({ setters: false }), errorHandler);
   }
 
   var errorHandler = function(error) {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
   "bin": {
     "migrate": "./bin/migrate"
   },
+  "scripts": {
+    "test": "NODE_ENV=test istanbul cover _mocha -- ./test",
+    "lint": "eslint ./lib ./test"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/mccraveiro/mongoose-lazy-migration.git"
@@ -29,8 +33,18 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "mongoose": "~3.8.2",
-    "slug": "~0.4.0",
-    "lodash": "^2.4.1"
+    "lodash": "^4.5.1",
+    "mongoose": "^4.4.5",
+    "slug": "~0.4.0"
+  },
+  "devDependencies": {
+    "babel-eslint": "5.0.0-beta9",
+    "eslint": "1.10.3",
+    "eslint-config-etaskr": "1.0.2",
+    "istanbul": "^0.4.2",
+    "mocha": "^2.4.5",
+    "moment-timezone": "^0.5.0",
+    "q": "^1.4.1",
+    "should": "^8.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "mongoose-lazy-migration",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Migrate your mongoose schemas as you go.",
   "author": "Mateus Craveiro <mccraveiro@gmail.com>",
   "contributors": [
-    "Kenneth Lee <kennethkl@gmail.com>"
+    "Kenneth Lee <kennethkl@gmail.com>",
+    "Theo Lubert <theo.lubert@gmail.com>"
   ],
   "keywords": [
     "mongoose",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-lazy-migration",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Migrate your mongoose schemas as you go.",
   "author": "Mateus Craveiro <mccraveiro@gmail.com>",
   "contributors": [

--- a/test/fixtures/data/blogs.json
+++ b/test/fixtures/data/blogs.json
@@ -1,0 +1,45 @@
+[
+    {
+        "_id": "56d3de05fb3ebd8320fca69a",
+        "title": "Electric cars will take over the world",
+        "body": "Following a strict mandate on air emissions in California, General Motors launches the EV-1 in 1997. It is an electric automobile that requires no gas, oil, muffler or brake changes and is, seemingly, the world's first perfect car. Yet six years later, GM recalls and destroys the EV-1 fleet. Now, Tesla is the future.",
+        "postedOn": "2016-02-28T00:00:00.000+0000",
+        "author": {
+            "_id": "56d3c5c99579571b0b103c4a",
+            "firstName": "Elon",
+            "nickname": "Elongated",
+            "__v": 0,
+            "social": {
+                "facebook": "https://www.facebook.com/Elon-Musk-19958149870/",
+                "twitter": "https://twitter.com/elonmusk",
+                "instagram": "https://www.instagram.com/elonmusk/"
+            }
+        },
+        "slug": "electric-car",
+        "comments": [
+        ],
+        "__v": 0
+    },
+    {
+        "_id": "56d3df763e98829b22230866",
+        "title": "Lean In: Women, Work, and the Will to Lead",
+        "body": "The book Lean In is focused on encouraging women to pursue their ambitions, and changing the conversation from what we can’t do to what we can do. LeanIn.Org is the next chapter.",
+        "postedOn": "2016-02-27T00:00:00.000+0000",
+        "author": {
+            "_id": "56d3c6c6418b70640dfc78ac",
+            "firstName": "Sheryl",
+            "lastName": "Sandberg",
+            "nickname": "Sandbags",
+            "__v": 0,
+            "social": {
+                "facebook": "https://www.facebook.com/sheryl",
+                "twitter": "https://twitter.com/sherylsandberg",
+                "instagram": "https://www.instagram.com/sherylsandberg/"
+            }
+        },
+        "slug": "lean-in",
+        "comments": [
+        ],
+        "__v": 0
+    }
+]

--- a/test/fixtures/data/users.json
+++ b/test/fixtures/data/users.json
@@ -1,0 +1,51 @@
+[
+    {
+        "_id": "56d3c5c99579571b0b103c4a",
+        "firstName": "Elon",
+        "nickname": "Elongated",
+        "social": {
+            "facebook": "https://www.facebook.com/Elon-Musk-19958149870/",
+            "twitter": "https://twitter.com/elonmusk",
+            "instagram": "https://www.instagram.com/elonmusk/"
+        },
+        "__v": 0
+    },
+    {
+        "_id": "56d3c6634a93b4da0cc02200",
+        "firstName": "Sergey",
+        "lastName": "Brin",
+        "__v": 0
+    },
+    {
+        "_id": "56d3c6c6418b70640dfc78ac",
+        "firstName": "Sheryl",
+        "lastName": "Sandberg",
+        "nickname": "Sandbags",
+        "social": {
+            "facebook": "https://www.facebook.com/sheryl",
+            "twitter": "https://twitter.com/sherylsandberg",
+            "instagram": "https://www.instagram.com/sherylsandberg/"
+        },
+        "__v": 0
+    },
+    {
+        "_id": "56d3d0dcfab35253117541fb",
+        "firstName": "Mark",
+        "nickname": "Zuc",
+        "social": {
+            "facebook": "https://www.facebook.com/zuck"
+        },
+        "__v": 0
+    },
+    {
+        "_id": "56d3d10d5b26cbd011be45bb",
+        "firstName": "Arianna",
+        "lastName": "Huffington",
+        "social": {
+            "facebook": "https://www.facebook.com/AriannaHuffingtonl",
+            "twitter": "https://twitter.com/ariannahuff",
+            "instagram": "https://www.instagram.com/ariannahuff/"
+        },
+        "__v": 0
+    }
+]

--- a/test/fixtures/models/blog.js
+++ b/test/fixtures/models/blog.js
@@ -1,0 +1,25 @@
+/**
+ * @author Josh Stuart <joshstuartx@gmail.com>
+ */
+
+var mongoose = require('mongoose');
+var User = require('./user');
+var Comment = require('./comment');
+var Schema = mongoose.Schema;
+
+var BlogSchema = new Schema({
+    title: String,
+    body: String,
+    postedOn: Date,
+    updatedOn: Date,
+    slug: String,
+    author: {
+        type: User.schema
+    },
+    comments: {
+        type: [Comment.schema],
+        default: []
+    }
+});
+
+module.exports = mongoose.model('Blog', BlogSchema);

--- a/test/fixtures/models/comment.js
+++ b/test/fixtures/models/comment.js
@@ -1,0 +1,18 @@
+/**
+ * @author Josh Stuart <joshstuartx@gmail.com>
+ */
+
+var mongoose = require('mongoose');
+var User = require('./user');
+var Schema = mongoose.Schema;
+
+var CommentSchema = new Schema({
+    title: String,
+    body: String,
+    postedOn: Date,
+    author: {
+        type: User.schema
+    }
+});
+
+module.exports = mongoose.model('Comment', CommentSchema);

--- a/test/fixtures/models/user.js
+++ b/test/fixtures/models/user.js
@@ -1,0 +1,19 @@
+/**
+ * @author Josh Stuart <joshstuartx@gmail.com>
+ */
+
+var mongoose = require('mongoose');
+var Schema = mongoose.Schema;
+
+var UserSchema = new Schema({
+    firstName: String,
+    lastName: String,
+    nickname: String,
+    social: {
+        facebook: String,
+        twitter: String,
+        instagram: String
+    }
+});
+
+module.exports = mongoose.model('User', UserSchema);

--- a/test/integration/migration-spec.js
+++ b/test/integration/migration-spec.js
@@ -1,0 +1,151 @@
+/**
+ * @author Josh Stuart <joshstuartx@gmail.com>
+ */
+var q = require('q');
+var should = require('should');
+var moment = require('moment-timezone');
+var _ = require('lodash');
+var migrate = require('../../lib/plugin');
+var db = require('../utils/db');
+var User = require('../fixtures/models/user');
+var userFixture = require('../fixtures/data/users');
+var Blog = require('../fixtures/models/blog');
+var blogFixture = require('../fixtures/data/blogs');
+var MIGRATIONS_PATH = __dirname + '/../fixtures/migrations/';
+
+/**
+ * Generic way to find by.
+ *
+ * @param collection
+ * @param value
+ * @param key
+ * @returns {Object}
+ */
+function findBy(collection, value, key) {
+    return _.find(collection, function(object) {
+        return object[key] === value;
+    });
+}
+
+/**
+ * Find a user in a collection by their name.
+ *
+ * @param users
+ * @param firstName
+ * @returns {Object}
+ */
+function findUserByFirstName(users, firstName) {
+    return findBy(users, firstName, 'firstName');
+}
+
+/**
+ * Find a blog in a collection by an id.
+ *
+ * @param blogs
+ * @param id
+ * @returns {Object}
+ */
+function findBlogById(blogs, id) {
+    return findBy(blogs, id, 'id');
+}
+
+describe('Migration Integration Specs', function() {
+    before(function(done) {
+        db.connect().
+        then(function() {
+            done();
+        });
+    });
+
+    after(function(done) {
+        done();
+    });
+
+    beforeEach(function(done) {
+        q.all([
+            db.import(User, userFixture),
+            db.import(Blog, blogFixture)
+        ]).
+        then(function() {
+            // apply the migration plugin to Users
+            User.schema.plugin(migrate, {
+                collection: 'users',
+                model: User,
+                migrations_path: MIGRATIONS_PATH
+            });
+
+            // apply the migration plugin to Blogs
+            Blog.schema.plugin(migrate, {
+                collection: 'blogs',
+                model: Blog,
+                migrations_path: MIGRATIONS_PATH
+            });
+
+            done();
+        });
+    });
+
+    afterEach(function(done) {
+        q.all([
+            db.removeAll(User),
+            db.removeAll(Blog)
+        ]).
+        then(function() {
+            done();
+        });
+    });
+
+    it('should run 2 migrations across the user collection and 1 across the blog collection', function(done) {
+        // run migration by querying
+        db.findAll(User).
+        then(function(users) {
+            var elon = findUserByFirstName(users, 'Elon');
+            var mark = findUserByFirstName(users, 'Mark');
+            var sergey = findUserByFirstName(users, 'Sergey');
+            var arianna = findUserByFirstName(users, 'Arianna');
+            var sheryl = findUserByFirstName(users, 'Sheryl');
+
+            // ensure migration has run up to the 2nd
+            elon.toObject().__m.should.eql(2);
+            mark.toObject().__m.should.eql(2);
+            sergey.toObject().__m.should.eql(2);
+            arianna.toObject().__m.should.eql(2);
+            sheryl.toObject().__m.should.eql(2);
+
+            // check last name migration user-0001
+            elon.lastName.should.eql('Musk');
+            mark.lastName.should.eql('Zuckerberg');
+            sergey.lastName.should.eql('Brin');
+            arianna.lastName.should.eql('Huffington');
+
+            // check nick name migration user-0002
+            should.not.exist(elon.nickname);
+            mark.nickname.should.eql('Zuck');
+            sergey.nickname.should.eql('G-Man');
+            sheryl.nickname.should.eql('Sandbags');
+
+            // run migration for blogs
+            return db.findAll(Blog);
+        }).
+        then(function(blogs) {
+            var updatedOn = moment('2016-02-29 00:00').tz('Australia/Melbourne');
+            var elonBlog = findBlogById(blogs, '56d3de05fb3ebd8320fca69a');
+            var sherylBlog = findBlogById(blogs, '56d3df763e98829b22230866');
+
+            // ensure migration has run up to the 1st
+            elonBlog.toObject().__m.should.eql(1);
+            sherylBlog.toObject().__m.should.eql(1);
+
+            // check migrations blogs-0001
+            elonBlog.updatedOn.should.eql(updatedOn.toDate());
+            elonBlog.title.should.eql('GM Killed the Electric Car, Tesla Revived It!');
+            elonBlog.slug.should.eql('gm-killed-the-electric-car-tesla-revived-it');
+
+            sherylBlog.updatedOn.should.eql(updatedOn.toDate());
+            sherylBlog.title.should.eql('Lean In: Women, Work, and the Will to Lead');
+            sherylBlog.slug.should.eql('lean-in-women-work-and-the-will-to-lead');
+
+            done();
+        });
+    });
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--reporter spec
+--ui bdd
+--recursive

--- a/test/utils/db.js
+++ b/test/utils/db.js
@@ -1,0 +1,244 @@
+/**
+ * @author Josh Stuart <joshstuartx@gmail.com>
+ */
+var q = require('q');
+var mongoose = require('mongoose');
+var CONNECTION_STRING = 'mongodb://localhost:27017/mongoose-lazy-migration-test';
+
+/**
+ * A DB util class that abstracts mongoose functions.
+ *
+ * @varructor
+ */
+function Db(options) {
+    options = options || {}; // eslint-disable-line no-param-reassign
+    this.autoReconnect = options.autoReconnect || false;
+}
+
+/**
+ * Returns the mongo connection url based on the current config.
+ *
+ * @returns {string}
+ * @private
+ */
+function getConnectionUrl() {
+    return CONNECTION_STRING;
+}
+
+/**
+ * Instantiate the database connection
+ *
+ * @returns {Promise}
+ * @public
+ */
+Db.prototype.connect = function() {
+    var connect;
+    var deferred = q.defer();
+
+    if (!this._db || this._db.readyState !== mongoose.Connection.STATES.connected) {
+        // Connect to mongodb
+        connect = function() {
+            var options = {server: {socketOptions: {keepAlive: 1}}};
+
+            mongoose.connect(getConnectionUrl(), options);
+        };
+
+        // connect to mongo
+        connect();
+
+        this._db = mongoose.connection;
+
+        this._db.on('error', function() {
+            throw new Error('unable to connect to database using: ' + getConnectionUrl());
+        });
+
+        this._db.on('connected', function() {
+            deferred.resolve();
+        });
+
+        this._db.on('disconnected', function() {
+            if (this.autoReconnect) {
+                connect();
+            }
+        }.bind(this));
+    } else {
+        // the db is still connected, so just resolve
+        deferred.resolve();
+    }
+
+    return deferred.promise;
+};
+
+/**
+ * Disconnects mongoose connection.
+ * @public
+ */
+Db.prototype.disconnect = function() {
+    if (!!this._db && this._db.readyState === mongoose.Connection.STATES.connected) {
+        this.autoReconnect = false;
+        this._db.close();
+        this._db = undefined;
+    }
+};
+
+/**
+ * A wrapper around the mongoose save function and returns a promise.
+ * @param object
+ * @returns {Promise}
+ * @public
+ */
+Db.prototype.create = function(object) {
+    return q.ninvoke(object, 'save').
+    then(function(result) {
+        if (result.constructor === Array && result.length > 0) {
+            return result[0];
+        }
+        return result;
+    });
+};
+
+/**
+ * A wrapper around the mongoose save function to 'update', even though they are the same thing as create,
+ * other ODMs may differ so this is a way to hedge for the future.
+ *
+ * @param object
+ */
+Db.prototype.update = function(object) {
+    return q.ninvoke(object, 'save').
+    then(function(result) {
+        if (result.constructor === Array && result.length > 0) {
+            return result[0];
+        }
+        return result;
+    });
+};
+
+/**
+ * Imports data by iterating and instantiating a schema one at a time, using serial promises.
+ *
+ * @param Schema
+ * @param data
+ * @returns {Promise}
+ * @public
+ */
+Db.prototype.import = function(Schema, data) {
+    return data.reduce(function(promise, entry) {
+        return this.create(new Schema(entry));
+    }.bind(this), q.resolve());
+};
+
+/**
+ * Removes all data from the passed collection schema.
+ *
+ * @param Schema
+ * @returns {Promise}
+ * @public
+ */
+Db.prototype.removeAll = function(Schema) {
+    return q.ninvoke(Schema, 'remove', {});
+};
+
+/**
+ * A wrapper function for the mongoose 'find'.
+ *
+ * @param Schema
+ * @param options
+ * @returns {Promise}
+ * @public
+ */
+Db.prototype.findAll = function(Schema, options) {
+    var query;
+
+    if (!options) {
+        options = { // eslint-disable-line no-param-reassign
+            criteria: {}
+        };
+    } else if (!options.criteria) {
+        options.criteria = {};
+    }
+
+    query = Schema.find(options.criteria);
+
+    if (!!options.populate) {
+        query.populate(options.populate);
+    }
+
+    if (!!options.lean) {
+        query.lean();
+    }
+
+    if (!!options.select) {
+        query.select(options.select);
+    }
+
+    return this.execute(query);
+};
+
+/**
+ * A wrapper function for the mongoose 'findOne'.
+ *
+ * @param Schema
+ * @param options
+ * @returns {Promise}
+ * @public
+ */
+Db.prototype.find = function(Schema, options) {
+    var query;
+
+    if (!options) {
+        options = { // eslint-disable-line no-param-reassign
+            criteria: {}
+        };
+    } else if (!options.criteria) {
+        options.criteria = {};
+    }
+
+    query = Schema.findOne(options.criteria);
+
+    if (!!options.populate) {
+        query = query.populate(options.populate);
+    }
+
+    if (!!options.lean) {
+        query.lean();
+    }
+
+    if (!!options.select) {
+        query.select(options.select);
+    }
+
+    return this.execute(query);
+};
+
+/**
+ * Wraps a mongoose query in a 'q' promise.
+ *
+ * @param query
+ * @returns {Promise}
+ * @public
+ */
+Db.prototype.execute = function(query) {
+    var deferred = q.defer();
+
+    query.exec(function(err, results) {
+        if (err) {
+            deferred.reject(err);
+        } else {
+            deferred.resolve(results);
+        }
+    });
+
+    return deferred.promise;
+};
+
+/**
+ * Returns the mongo connection.
+ *
+ * @returns {*}
+ * @public
+ */
+Db.prototype.getConnection = function() {
+    return this._db;
+};
+
+module.exports = new Db();


### PR DESCRIPTION
I forked from @theo-lubert who attempted to fix this problem, but I believe it still didn't quite solve it fully (I'm not sure a "contributor" credit is justified here tbh, but I'll leave that up to you).

The problem was the `currentVersion` and `migrations` were being "cached". So instead of retrieving it only once, we retrieve them every time a `preInit` or `migrate` call is made. This ensures that even with multiple collections, versions and asynchronicities, we will retrieve the correct version number for the specific schema/collection at the correct time.

There may be some concerns about performance now since these are no longer "cached", but overall they should be relatively insignificant. The `common.getCurrentVersion` should be fine since the `require` is already cached, but the `common.listByVersion` could be optimized. Happy for suggestions here.

I also:
- Added an integration test since there was `0%` coverage. This was a quick way to get full end-to-end coverage of a multi-collection migration. To run do `npm test`. It also provides a coverage report: `~72%` of lines, but `~44%` branches, which isn't great but that would be because of the `cli` code (which I didn't write any tests for). However, it is a big improvement over `0%`.
- Added `eslint` code style based on https://github.com/airbnb/javascript with a few minor tweaks. I didn't fix all code style problems because there were a fair few in `cli`. To check run; `npm run lint`.

TODO:
- Unit tests for `cli`
- Other integration tests that cover different scenarios.
- Continue code style fixes and add `npm run lint` to `npm test` so that we prevent code style problems entering the codebase again.
